### PR TITLE
api: do not assume presence of content-type header

### DIFF
--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -289,7 +289,7 @@ class Api:
 		if self._debug:
 			print(r.status_code)
 
-		content_type = r.headers['content-type']
+		content_type = r.headers.get('content-type')
 
 		if content_type in ["application/json", "application/vnd.api+json"]:
 			payload = r.json()


### PR DESCRIPTION
Use `headers.get('content-type')` instead of `headers['content-type']` since the `content-type` header may not exist. As one example, `DELETE /v1/users/{id}` returns 204 with no content and thus no `content-type` header.